### PR TITLE
Verificar que cada CDN requerido posea SSL

### DIFF
--- a/app/views/admin/layouts/_head.html.haml
+++ b/app/views/admin/layouts/_head.html.haml
@@ -1,6 +1,6 @@
 %head
   %meta{:name => "viewport", :content => "width=device-width, initial-scale=1.0"}
-  %link{href:'http://fonts.googleapis.com/css?family=Patua+One', rel:'stylesheet', type:'text/css'}
+  %link{href:'https://fonts.googleapis.com/css?family=Patua+One', rel:'stylesheet', type:'text/css'}
   %link{:href => "https://fonts.googleapis.com/icon?family=Material+Icons", :rel => "stylesheet"}/
   %title= content_for?(:title) ? yield(:title) : 'Keppler Admin'
   = stylesheet_link_tag 'admin/application', media: 'all'

--- a/app/views/app/layouts/_head.html.haml
+++ b/app/views/app/layouts/_head.html.haml
@@ -4,12 +4,12 @@
 // Stylesheets
 = stylesheet_link_tag 'app/application', media: 'all', 'data-turbolinks-track' => true
 %link{href:'https://fonts.googleapis.com/css?family=Patua+One', rel:'stylesheet', type:'text/css'}
-%link{:href => "//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/default.min.css", :rel => "stylesheet"}/
+%link{:href => "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/default.min.css", :rel => "stylesheet"}/
 
 // Javascripts
 = javascript_include_tag 'app/application', 'data-turbolinks-track' => true
 = render "app/layouts/google_adwords"
-%script{:src => "//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"}
+%script{:src => "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"}
 
 // Google Analytics
 = render 'app/layouts/google_analytics'

--- a/app/views/app/layouts/_head.html.haml
+++ b/app/views/app/layouts/_head.html.haml
@@ -3,7 +3,7 @@
 
 // Stylesheets
 = stylesheet_link_tag 'app/application', media: 'all', 'data-turbolinks-track' => true
-%link{href:'http://fonts.googleapis.com/css?family=Patua+One', rel:'stylesheet', type:'text/css'}
+%link{href:'https://fonts.googleapis.com/css?family=Patua+One', rel:'stylesheet', type:'text/css'}
 %link{:href => "//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/default.min.css", :rel => "stylesheet"}/
 
 // Javascripts


### PR DESCRIPTION
ref #80 

### Cambiar link de los cdn que requieren Patua One de Google Fonts, por los que poseen SSL, en:
- [x] `app/views/admin/layouts/_head.html.haml`
- [x] `app/views/app/layouts/_head.html.haml`
### Agregar `https` a los cdn de highlight.js en: 
- [x] `app/views/app/layouts/_head.html.haml (line: 7, 12)`