### PR TITLE
solved bug in destroy_multiple method

### DIFF
--- a/app/controllers/admin/admin_controller.rb
+++ b/app/controllers/admin/admin_controller.rb
@@ -65,7 +65,7 @@ module Admin
       klass = is_admin ? controller_name : controller_path
 
       redefine_ids(params[:multiple_ids]).each do |id|
-        authorize! :destroy, klass.classify.constantize.find(id)
+        authorize klass.classify.constantize.find(id)
       end
     end
   end

--- a/app/controllers/admin/meta_tags_controller.rb
+++ b/app/controllers/admin/meta_tags_controller.rb
@@ -74,7 +74,6 @@ module Admin
         admin_meta_tags_path(page: @current_page, search: @query),
         notice: actions_messages(MetaTag.new)
       )
-      authorize @meta_tag
     end
 
     def upload

--- a/app/views/admin/meta_tags/_listing.html.haml
+++ b/app/views/admin/meta_tags/_listing.html.haml
@@ -29,7 +29,7 @@
               = t('keppler.actions.edit')
         - if can?(MetaTag).clone?
           %li
-            = link_to admin_meta_tag_path(meta_tag), class: 'new-menu', title: t('keppler.actions.clone') do
+            = link_to admin_meta_tag_clone_path(meta_tag), class: 'new-menu', title: t('keppler.actions.clone') do
               %i.icon-docs
               = t('keppler.actions.clone')
         - if can?(MetaTag).destroy?


### PR DESCRIPTION
Solucioné el error al eliminar múltiples registros, y además un error que detecté al clonar meta_tags