### PR TITLE
enmachs/file_size/157

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ gem 'simple_form', '4.0.0'
 # Upload
 gem 'carrierwave', '1.2.2'
 gem 'rmagick', '2.16.0' # fix issue: 'sudo apt install libmagick++-dev'
+gem 'carrierwave-imageoptimizer', '~> 1.4'
 
 # Design
 gem 'bootstrap-sass', '3.3.7'

--- a/app/uploaders/attachment_uploader.rb
+++ b/app/uploaders/attachment_uploader.rb
@@ -12,6 +12,7 @@ class AttachmentUploader < CarrierWave::Uploader::Base
   storage :file
   # storage :fog
   process :optimize
+  process quality: 100
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:
@@ -23,10 +24,9 @@ class AttachmentUploader < CarrierWave::Uploader::Base
     return_size_type(file.content_type)
   end
 
-  # version :thumb do
-  #   process :resize_to_fit => [100, 100]
-  #   process :quality => 100 
-  # end
+  version :thumb do
+    process resize_to_fit: [200, 200]
+  end
   # Provide a default URL as a default if there hasn't been a file uploaded:
 
   # Process files as they are uploaded:

--- a/app/uploaders/attachment_uploader.rb
+++ b/app/uploaders/attachment_uploader.rb
@@ -3,12 +3,15 @@
 # AttachmentUploader Carrierwave
 class AttachmentUploader < CarrierWave::Uploader::Base
   # Include RMagick or MiniMagick support:
-  # include CarrierWave::RMagick
+  include CarrierWave::RMagick
+  include CarrierWave::ImageOptimizer
+
   # include CarrierWave::MiniMagick
 
   # Choose what kind of storage to use for this uploader:
   storage :file
   # storage :fog
+  process :optimize
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:
@@ -20,6 +23,10 @@ class AttachmentUploader < CarrierWave::Uploader::Base
     return_size_type(file.content_type)
   end
 
+  # version :thumb do
+  #   process :resize_to_fit => [100, 100]
+  #   process :quality => 100 
+  # end
   # Provide a default URL as a default if there hasn't been a file uploaded:
 
   # Process files as they are uploaded:
@@ -48,7 +55,7 @@ class AttachmentUploader < CarrierWave::Uploader::Base
   private
 
   def return_size_type(file)
-    return 0.1..2.megabytes if file.include?('image')
-    0.1..5.megabytes
+    return 0..1.megabytes if file.include?('image')
+    0..5.megabytes
   end
 end

--- a/app/uploaders/attachment_uploader.rb
+++ b/app/uploaders/attachment_uploader.rb
@@ -16,6 +16,10 @@ class AttachmentUploader < CarrierWave::Uploader::Base
     "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
   end
 
+  def size_range
+    return_size_type(file.content_type)
+  end
+
   # Provide a default URL as a default if there hasn't been a file uploaded:
 
   # Process files as they are uploaded:
@@ -41,4 +45,10 @@ class AttachmentUploader < CarrierWave::Uploader::Base
   # def filename
   #   "something.jpg" if original_filename
   # end
+  private
+
+  def return_size_type(file)
+    return 0.1..2.megabytes if file.include?('image')
+    0.1..5.megabytes
+  end
 end

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,0 +1,12 @@
+
+module CarrierWave
+  module RMagick
+    def quality(percentage)
+      manipulate! do |img|
+        img.write(current_path){ self.quality = percentage } unless img.quality == percentage
+        img = yield(img) if block_given?
+        img
+      end
+    end
+  end
+end

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -312,6 +312,7 @@ es:
   errors:
     format: ! '%{attribute} %{message}'
     messages:
+      max_size_error: "Archivo demasiado pesado"
       tipo_transaccion: no puede realizarse, el artículo no posee existencia
       lista_de_articulos: no puede estar vacía
       stock_maximo: no puede ser menor al stock mínimo

--- a/lib/generators/keppler_scaffold/templates/views/_form.html.haml
+++ b/lib/generators/keppler_scaffold/templates/views/_form.html.haml
@@ -28,6 +28,7 @@
                         #icon-file
                           +
                         = f.file_field :<%= attribute.name %>, class: 'photo_upload'
+                        = f.error :<%= attribute.name %>, style: "color: red;"
                       %center#image
                         = image_tag "#{@<%= singular_table_name %>.<%= attribute.name %>.blank? ? '<%= attribute.name %>.png' : @<%= singular_table_name %>.<%= attribute.name %>}", class: "#{'hidden' if @<%= singular_table_name %>.<%= attribute.name %>.blank?} image_to_upload"
                     <%- end -%>


### PR DESCRIPTION
- Añadido método `size_range` al `app/uploaders/attachment_uploader.rb`
- Validado peso tanto de imágenes como de archivos diferentes a este. (max 500kb y max 5mb respectivamente.
- Agregada traducción de `max_size_error` en `config/locales/es.yml`.
- Agregada nueva línea de `f.error` debajo de los `f.file_field` en los generadores.
- Añadida `CarrierWave::ImageOptimizer` al `app/uploaders/attachment_uploader.rb`
- Versión thumb generada automáticamente de 200x200 para todas las imágenes.