### PR TITLE
Arreglado funcionamiento de drag n' drop del listing de módulos

### DIFF
--- a/app/assets/stylesheets/admin/pages/_index.scss
+++ b/app/assets/stylesheets/admin/pages/_index.scss
@@ -320,10 +320,6 @@
   }
 }
 
-.ui-sortable-helper{
-  display: table;
-  background-color: #fdfdfd;
-}
 #tools{
   padding: {
     top: 5px;

--- a/app/assets/stylesheets/admin/pages/_listing.scss
+++ b/app/assets/stylesheets/admin/pages/_listing.scss
@@ -27,3 +27,8 @@
 .ui-sortable-handle{
   width: 50px;
 }
+.ui-sortable-helper{
+  // width: 50px;
+  display: table;
+  background-color: #fdfdfd;
+}

--- a/app/assets/stylesheets/admin/pages/_search.scss
+++ b/app/assets/stylesheets/admin/pages/_search.scss
@@ -67,7 +67,7 @@
   height: 34px;
   width: 34px;
   padding: 5px;
-  margin: 8px;
+  margin: 10px;
   color: #999;
   opacity: 0;
   border-radius: 50%;

--- a/app/models/concerns/sortable.rb
+++ b/app/models/concerns/sortable.rb
@@ -1,8 +1,9 @@
 # Keppler
 module Sortable
   extend ActiveSupport::Concern
-
-  def self.sorter(params)
-    params.each_with_index { |id, idx| find(id).update(position: idx.to_i + 1) }
+  included do
+    def self.sorter(params)
+      params.each_with_index { |id, idx| find(id).update(position: idx.to_i + 1) }
+    end
   end
 end

--- a/app/policies/controller_policy.rb
+++ b/app/policies/controller_policy.rb
@@ -50,4 +50,8 @@ class ControllerPolicy < ApplicationPolicy
   def download?
     keppler_admin? || user_can?(@objects, 'download')
   end
+
+  def sort?
+    keppler_admin? || user_can?(@objects, 'sort')
+  end
 end

--- a/app/views/admin/layouts/_navigation.html.haml
+++ b/app/views/admin/layouts/_navigation.html.haml
@@ -15,7 +15,7 @@
             = f.search_field search_model, placeholder: "#{t('keppler.actions.search')}...", class: 'form-control search-bar'
           %span.input-group-btn
             %button.btn.search-button.toggle-search{ type: 'submit' }
-              %i.icon-magnifier.search-icon
+              %i.icon-magnifier.search-icon{ style: 'line-height: 1.4;' }
       .hide-search
         %i.fa.fa-arrow-left
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,6 @@ Rails.application.routes.draw do
   namespace :admin do
     root to: 'admin#root'
 
-
     resources :roles do
       get '(page/:page)', action: :index, on: :collection, as: ''
       get '/clone', action: 'clone'

--- a/lib/generators/keppler_scaffold/keppler_scaffold_generator.rb
+++ b/lib/generators/keppler_scaffold/keppler_scaffold_generator.rb
@@ -156,15 +156,15 @@ module Rails
         invoke invoked, [controller_name]
       end
 
-      def add_position_field
-        file = Dir::entries('db/migrate').max
-        # system 'sudo apt-get update'
-        inject_into_file(
-          "db/migrate/#{file}",
-          "t.integer :position\n      ",
-          before: 't.timestamps null: false'
-        )
-      end
+      # def add_position_field
+      #   file = Dir::entries('db/migrate').max
+      #   # system 'sudo apt-get update'
+      #   inject_into_file(
+      #     "db/migrate/#{file}",
+      #     "t.integer :position\n      ",
+      #     before: 't.timestamps'
+      #   )
+      # end
 
       private
 
@@ -185,7 +185,7 @@ module Rails
       end
 
       def str_route
-        "\n  resources :#{controller_file_name} do\n    get '(page/:page)', action: :index, on: :collection, as: ''\n    get '/clone', action: 'clone'\n    post '/upload', action: 'upload', as: :upload\n    post(\n      '/sort',\n      action: :sort,\n      on: :collection,\n    )\n    get(\n      '/reload',\n      action: :reload,\n      on: :collection,\n    )\n    delete(\n      '/destroy_multiple',\n      action: :destroy_multiple,\n      on: :collection,\n      as: :destroy_multiple\n    )\n  end"
+        "\n  resources :#{controller_file_name} do\n    post '/sort', action: :sort, on: :collection\n    get '(page/:page)', action: :index, on: :collection, as: ''\n    get '/clone', action: 'clone'\n    post '/upload', action: 'upload', as: :upload\n    get(\n      '/reload',\n      action: :reload,\n      on: :collection,\n    )\n    delete(\n      '/destroy_multiple',\n      action: :destroy_multiple,\n      on: :collection,\n      as: :destroy_multiple\n    )\n  end"
       end
 
       def str_menu

--- a/lib/generators/keppler_scaffold/templates/controllers/controller.rb
+++ b/lib/generators/keppler_scaffold/templates/controllers/controller.rb
@@ -94,7 +94,9 @@ module Admin
 
     def sort
       <%= class_name %>.sorter(params[:row])
-      render :index
+      @q = <%= class_name %>.ransack(params[:q])
+      <%= plural_table_name %> = @q.result(distinct: true)
+      @objects = <%= plural_table_name %>.page(@current_page)
     end
 
     private

--- a/lib/generators/keppler_scaffold/templates/controllers/controller.rb
+++ b/lib/generators/keppler_scaffold/templates/controllers/controller.rb
@@ -14,9 +14,9 @@ module Admin
     def index
       @q = <%= class_name %>.ransack(params[:q])
       <%= plural_table_name %> = @q.result(distinct: true)
-      @objects = <%= plural_table_name %>.page(@current_page).order(position: :desc)
+      @objects = <%= plural_table_name %>.page(@current_page).order(position: :asc)
       @total = <%= plural_table_name %>.size
-      @<%= plural_table_name %> = @objects.order(:position)
+      @<%= plural_table_name %> = <%= class_name %>.all
       if !@objects.first_page? && @objects.size.zero?
         redirect_to <%= plural_table_name %>_path(page: @current_page.to_i.pred, search: @query)
       end


### PR DESCRIPTION
Lo realizado:
- Agregado a bloque `included` la función dentro del concern `sortable.rb`
- Método `sort``agregado al `controller_policy.rb`
- Movido al tope la ruta post de sort en los generadores
- Comentado función en `keppler_scaffold_generator.rb` que agrega el campo `:position` en la migración generada 